### PR TITLE
Add Datacard and Modelcard reference to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Project Organization
     │   ├── processed      <- The final, canonical data sets for modeling.
     │   └── raw            <- The original, immutable data dump.
     │
-    ├── docs               <- A default Sphinx project; see sphinx-doc.org for details
+    ├── docs               <- Contains information about model and dataset (Datacard.md and Modelcard.md)
     │
     ├── models             <- Trained and serialized models, model predictions, or model summaries
     │


### PR DESCRIPTION
Changed README.md file to contain references to Datacard and Modelcard inside docs folder.